### PR TITLE
feat: reduce dependency size

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "glob": "^8.0.3",
     "ms": "^2.1.3",
     "ts-dotenv": "^0.8.3",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
@@ -30,6 +29,8 @@
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.26.0",
+    "typescript": "^4.7.4",
+    "ts-node": "^10.9.1" 
   }
 }


### PR DESCRIPTION
u added typescript and ts-node as dependencies, when they should be dev deps

This will probably reduce the size of a discord bot in production by a lot